### PR TITLE
DermaRequest Library

### DIFF
--- a/Clockwork/garrysmod/gamemodes/clockwork/framework/libraries/sh_dermarequest.lua
+++ b/Clockwork/garrysmod/gamemodes/clockwork/framework/libraries/sh_dermarequest.lua
@@ -1,0 +1,72 @@
+--[[
+	© 2013 CloudSixteen.com do not share, re-distribute or modify
+	without permission of its author (kurozael@gmail.com).
+--]]
+
+--[[
+	@codebase Shared
+	@details A library to send Derma String Requests to clients through the server. It can also send simple Derma messages.
+--]]
+Clockwork.dermaRequest = Clockwork.kernel:NewLibrary("DermaRequest");
+
+local REQUEST_INDEX = 0;
+function Clockwork.dermaRequest:GenerateID()
+	REQUEST_INDEX = REQUEST_INDEX + 1;
+	return os.time() + REQUEST_INDEX;
+end
+
+if (SERVER) then
+
+	Clockwork.dermaRequest.hooks = {};
+
+	--[[
+		@codebase Server
+		@details Requests a string in the form of a Derma Popup on the specified client.
+		@param Player Target client
+		@param String Title to apply to the Derma popup
+		@param String Question to ask in the Derma popup
+		@param String Default entry in the text box
+		@param Function Callback(answer)
+	--]]
+	function Clockwork.dermaRequest:RequestString(player, title, question, default, Callback)
+		local rID = self:GenerateID();
+		Clockwork.datastream:Start(player, "dermaRequest_stringQuery", {id = rID, title = title, question = question, default = default});
+		self.hooks[rID] = {Callback = Callback, player = player};
+	end
+
+	function Clockwork.dermaRequest:Message(player, message, title, button)
+		Clockwork.datastream:Start(player, "dermaRequest_message", {message = message, title = title or nil, button = button or nil});
+	end
+
+	function Clockwork.dermaRequest:Validate(player, data)
+		if (data.id and data.recv and self.hooks[data.id] and self.hooks[data.id].player == player) then
+			return true;
+		end
+		return false;
+	end
+
+	Clockwork.datastream:Hook("dermaRequestCallback", function(player, data)
+		if (!Clockwork.dermaRequest:Validate(player, data)) then return; end;
+		Clockwork.dermaRequest.hooks[data.id].Callback(data.recv);
+		Clockwork.dermaRequest.hooks[data.id] = nil;
+	end);
+
+else
+
+	function Clockwork.dermaRequest:Send(id, recv)
+		Clockwork.datastream:Start("dermaRequestCallback", {id = id, recv = recv});
+	end
+
+	Clockwork.datastream:Hook("dermaRequest_stringQuery", function(data)
+		Derma_StringRequest(data.title, data.question, data.default, function(recv)
+			Clockwork.dermaRequest:Send(data.id, recv);
+		end);
+	end);
+
+	Clockwork.datastream:Hook("dermaRequest_message", function(data)
+		local title = data.title or nil;
+		local button = data.button or nil;
+		Derma_Message(data.message, data.title, data.button);
+	end);
+
+end


### PR DESCRIPTION
# DermaRequest Library

_A simple library that adds the ability for the server to easily request strings from the client. It can also be used to push Derma message boxes to players!_
## Usage

There are currently two simple functions in the DermaRequest.\* library.
`RequestString(Player ply, String title, String question, String default, Func Callback)`
`Message(Player player, String message, String title, String buttontext)`
## Examples

The following example adds a command named FavoriteColor, which when ran will request from the player their favorite color using the DermaRequest library. Specifically, this example uses the `RequestString`

``` lua
local COMMAND = Clockwork.command:New("FavoriteColor");
COMMAND.tip = "Asks you a simple question!";
COMMAND.flags = CMD_DEFAULT;

-- Called when the command has been run.
function COMMAND:OnRun(player, entity)
    Clockwork.dermaRequest:RequestString(player, "Title of DFrame", "What is your favorite color?", "", function(text)
        Clockwork.player:Notify(player, "You told the server your favorite color is: "..text..".")
    end)
end;

COMMAND:Register();
```

The next example makes it known to a player that flashlights are disabled. This uses the `Message` method.

``` lua
-- Called when a player switches their flashlight on or off.
function Schema:PlayerSwitchFlashlight(player, on)
    Clockwork.dermaRequest:Message(player, "Ouch! The light hurts... stop turning it on.", "No Flashlights.", "I'm Sorry")
    return false;
end;
```
## Amendment

Obviously the examples given on this page aren't to be used in production, they just show how to use the functions. There are many practical uses for these functions such as asking for input while running commands, using items and entities, and much more. Sending Derma popup messages is a more prompt method of alerting a player if the information is a "must-see". Overall, the DermaRequest library is used in Slidefuse schemas and it's saved a lot of otherwise unneeded work.
