### PR TITLE
Update init.lua

### DIFF
--- a/Clockwork/garrysmod/gamemodes/clockwork/framework/entities/entities/cw_cash/init.lua
+++ b/Clockwork/garrysmod/gamemodes/clockwork/framework/entities/entities/cw_cash/init.lua
@@ -19,7 +19,7 @@ function ENT:Initialize()
 	self:SetUseType(SIMPLE_USE);
 	self:SetHealth(25);
 	self:SetSolid(SOLID_VPHYSICS);
-	self:SetCollisionGroup(COLLISION_GROUP_DEBRIS);
+	self:SetCollisionGroup(COLLISION_GROUP_DEBRIS_TRIGGER);
 	
 	local physicsObject = self:GetPhysicsObject();
 	


### PR DESCRIPTION
No-collides the cash entity with nothing but world, preventing issue #32
