### PR TITLE
Extended item options capabilities.

### DIFF
--- a/Clockwork/garrysmod/gamemodes/clockwork/framework/libraries/sh_item.lua
+++ b/Clockwork/garrysmod/gamemodes/clockwork/framework/libraries/sh_item.lua
@@ -222,6 +222,10 @@ if (SERVER) then
 			self.networkQueue = {};
 		end);
 	end;
+else
+	function CLASS_TABLE:SubmitOption(option, data, entity)
+		Clockwork.datastream:Start("MenuOption", {option = option, data = data, item = self("itemID"), entity = entity});
+	end;
 end;
 
 --[[

--- a/Clockwork/garrysmod/gamemodes/clockwork/framework/sv_kernel.lua
+++ b/Clockwork/garrysmod/gamemodes/clockwork/framework/sv_kernel.lua
@@ -3578,6 +3578,30 @@ Clockwork.datastream:Hook("EntityMenuOption", function(player, data)
 	end;
 end);
 
+-- MenuOption datastream callback.
+Clockwork.datastream:Hook("MenuOption", function(player, data)
+	local item = data.item;
+	local option = data.option;
+	local entity = data.entity;
+	local data = data.data;
+	local shootPos = player:GetShootPos();
+
+	if (type(data) != "table") then
+		data = {data};
+	end;
+
+	local itemTable = Clockwork.item:FindInstance(item);
+	if (itemTable and itemTable:IsInstance() and type(option) == "string") then
+		if (itemTable.HandleOptions) then
+			if (player:HasItemInstance(itemTable)) then
+				itemTable:HandleOptions(option, player, data);
+			elseif (IsValid(entity) and entity:GetClass() == "cw_item" and entity:GetItemTable() == itemTable and entity:NearestPoint(shootPos):Distance(shootPos) <= 80) then
+				itemTable:HandleOptions(option, player, data, entity);
+			end;
+		end;
+	end;
+end);
+
 -- DataStreamInfoSent datastream callback.
 Clockwork.datastream:Hook("DataStreamInfoSent", function(player, data)
 	if (!player.cwDataStreamInfoSent) then


### PR DESCRIPTION
This is something I absolutely need in my schema since I'm making full use of the item system, and the current option system does not have enough functionality. It should not interfere anyhow with the normal way of how options work, and is basically just another way for handling them.
