### PR TITLE
Clamp Headbob Scale

### DIFF
--- a/Clockwork/garrysmod/gamemodes/clockwork/framework/cl_kernel.lua
+++ b/Clockwork/garrysmod/gamemodes/clockwork/framework/cl_kernel.lua
@@ -841,7 +841,7 @@ end;
 
 -- Called when the view should be calculated.
 function Clockwork:CalcView(player, origin, angles, fov)
-	local scale = CW_CONVAR_HEADBOBSCALE:GetFloat() or 1;
+	local scale = math.Clamp(CW_CONVAR_HEADBOBSCALE:GetFloat(),0,1) or 1;
 
 	if (self.Client:IsRagdolled()) then
 		local ragdollEntity = self.Client:GetRagdollEntity();
@@ -2423,7 +2423,7 @@ function Clockwork:PlayerAdjustClassModelInfo(class, info) end;
 -- Called when the local player's headbob info should be adjusted.
 function Clockwork:PlayerAdjustHeadbobInfo(info)
 	local bisDrunk = self.player:GetDrunk();
-	local scale = CW_CONVAR_HEADBOBSCALE:GetFloat() or 1;
+	local scale = math.Clamp(CW_CONVAR_HEADBOBSCALE:GetFloat(),0,1) or 1;
 	
 	if (self.Client:IsRunning()) then
 		info.speed = (info.speed * 4) * scale;


### PR DESCRIPTION
Clamped Headbob Scale 0-1, unclamped can cause problems if set higher than 1. 
(Can no longer simulate "COD montage mode")
