### PR TITLE
Added commands alias

### DIFF
--- a/Clockwork/garrysmod/gamemodes/clockwork/framework/libraries/client/cl_chatbox.lua
+++ b/Clockwork/garrysmod/gamemodes/clockwork/framework/libraries/client/cl_chatbox.lua
@@ -895,11 +895,25 @@ function Clockwork.chatBox:Paint()
 		local prefix = Clockwork.config:Get("command_prefix"):Get();
 		
 		if (command and command != "") then
-			for k, v in pairs(Clockwork.command.stored) do
+			for k, v in pairs(Clockwork.command:GetAlias()) do
 				if (string.utf8sub(k, 1, string.utf8len(command)) == string.lower(command)
 				and (!splitTable[2] or string.lower(command) == k)) then
-					if (Clockwork.player:HasFlags(Clockwork.Client, v.access)) then
-						commands[#commands + 1] = v;
+					local cmdTable = Clockwork.command:FindByAlias(v);
+
+					if (Clockwork.player:HasFlags(Clockwork.Client, cmdTable.access)) then
+						local bShouldAdd = true;
+
+						-- It can so happen that multiple alias for the same command begin with the same string.
+						-- We don't want to display the same command multiple times, so we check for that.
+						for k, v in pairs(commands) do
+							if (v == cmdTable) then
+								bShouldAdd = false;
+							end;
+						end;
+
+						if (bShouldAdd) then
+							commands[#commands + 1] = cmdTable;
+						end;
 					end;
 				end;
 				

--- a/Clockwork/garrysmod/gamemodes/clockwork/framework/libraries/sh_command.lua
+++ b/Clockwork/garrysmod/gamemodes/clockwork/framework/libraries/sh_command.lua
@@ -18,6 +18,7 @@ local hook = hook;
 Clockwork.command = Clockwork.kernel:NewLibrary("Command");
 Clockwork.command.stored = Clockwork.command.stored or {};
 Clockwork.command.hidden = Clockwork.command.hidden or {};
+local alias = {};
 
 CMD_KNOCKEDOUT = 2;
 CMD_FALLENOVER = 4;
@@ -79,6 +80,16 @@ function Clockwork.command:Register(data, name)
 		end;
 	end;
 
+	-- We do that so the Command Interpreter can find the command
+	-- if it's original, non-aliased name has been used.
+	alias[uniqueID] = uniqueID;
+
+	if (data.alias and type(data.alias) == "table") then
+		for k, v in pairs(data.alias) do
+			alias[tostring(v)] = uniqueID;
+		end;
+	end;
+
 	self.stored[uniqueID] = data;
 	self.stored[uniqueID].name = realName;
 	self.stored[uniqueID].text = data.text or "<none>";
@@ -98,12 +109,29 @@ function Clockwork.command:FindByID(identifier)
 	return self.stored[string.lower(string.gsub(identifier, "%s", ""))];
 end;
 
+--[[
+	@codebase Shared
+	@details Returns command's table by alias or unique id.
+	@param ID Identifier of the command to find. Can be alias or original command name.
+--]]
+function Clockwork.command:FindByAlias(id)
+	return self.stored[alias[id]] or nil;
+end;
+
+--[[
+	@codebase Shared
+	@details Returns table of all comamnd alias indexed by alias' names.
+--]]
+function Clockwork.command:GetAlias()
+	return alias;
+end;
+
 if (SERVER) then
 	function Clockwork.command:ConsoleCommand(player, command, arguments)
 		if (player:HasInitialized()) then
 			if (arguments and arguments[1]) then
 				local realCommand = string.lower(arguments[1]);
-				local commandTable = self.stored[realCommand];
+				local commandTable = self:FindByAlias(realCommand);
 				local commandPrefix = Clockwork.config:Get("command_prefix"):Get();
 
 				if (commandTable) then
@@ -178,10 +206,10 @@ if (SERVER) then
 						end;
 					end;
 				elseif (!Clockwork.player:GetDeathCode(player, true)) then
-					Clockwork.player:Notify(player, "This is not a valid command!");
+					Clockwork.player:Notify(player, "This is not a valid command or alias!");
 				end;
 			elseif (!Clockwork.player:GetDeathCode(player, true)) then
-				Clockwork.player:Notify(player, "This is not a valid command!");
+				Clockwork.player:Notify(player, "This is not a valid command or alias!");
 			end;
 
 			if (Clockwork.player:GetDeathCode(player)) then

--- a/Clockwork/garrysmod/gamemodes/clockwork/framework/sv_kernel.lua
+++ b/Clockwork/garrysmod/gamemodes/clockwork/framework/sv_kernel.lua
@@ -2294,7 +2294,7 @@ function Clockwork:PlayerSay(player, text, bPublic)
  	if (string.sub(text, 1, prefixLength) == prefix) then
 		local arguments = Clockwork.kernel:ExplodeByTags(text, " ", "\"", "\"", true);
 		local command = string.sub(arguments[1], prefixLength + 1);
-		local realCommand = Clockwork.command:GetAlias()[command];
+		local realCommand = Clockwork.command:GetAlias()[command] or command;
 
 		return string.Replace(text, prefix..command, prefix..realCommand);
  	end;

--- a/Clockwork/garrysmod/gamemodes/clockwork/framework/sv_kernel.lua
+++ b/Clockwork/garrysmod/gamemodes/clockwork/framework/sv_kernel.lua
@@ -2287,7 +2287,18 @@ function Clockwork:PlayerCanUseCommand(player, commandTable, arguments)
 end;
 
 -- Called when a player speaks from the client.
-function Clockwork:PlayerSay(player, text, bPublic) end;
+function Clockwork:PlayerSay(player, text, bPublic)
+	local prefix = Clockwork.config:Get("command_prefix"):Get();
+	local prefixLength = string.len(prefix);
+
+ 	if (string.sub(text, 1, prefixLength) == prefix) then
+		local arguments = Clockwork.kernel:ExplodeByTags(text, " ", "\"", "\"", true);
+		local command = string.sub(arguments[1], prefixLength + 1);
+		local realCommand = Clockwork.command:GetAlias()[command];
+
+		return string.Replace(text, prefix..command, prefix..realCommand);
+ 	end;
+end;
 
 -- Called when a player attempts to suicide.
 function Clockwork:CanPlayerSuicide(player) return false; end;


### PR DESCRIPTION
THIS CODE IS UNTESTED!

Added the ability to set commands’ alias while registering them. Simply
add “COMMAND.alias = {“table”, “of”, “alias”}” to command file.

So for example, we have /me command and we add “COMMAND.alias =
{“notme”}” to it’s file. Then using
/notme does something.
will have exactly the same effect as using
/me does something.