### PR TITLE
Force fonts to use extended character range

### DIFF
--- a/Clockwork/garrysmod/gamemodes/clockwork/framework/libraries/client/cl_fonts.lua
+++ b/Clockwork/garrysmod/gamemodes/clockwork/framework/libraries/client/cl_fonts.lua
@@ -21,6 +21,7 @@ Clockwork.fonts.sizes = Clockwork.fonts.sizes or {};
 
 -- A function to add a new font to the system.
 function Clockwork.fonts:Add(name, fontTable)
+	fontTable.extended = true; -- Force the font to load all characters.
 	self.stored[name] = fontTable;
 	CreateFont(name, self.stored[name]);
 end;
@@ -63,7 +64,8 @@ Clockwork.fonts:Add("cwMainText",
 	size		= Clockwork.kernel:FontScreenScale(7),
 	weight		= 700,
 	antialiase	= true,
-	additive 	= false
+	additive 	= false,
+	extended	= true
 });
 Clockwork.fonts:Add("cwESPText", 
 {
@@ -71,7 +73,8 @@ Clockwork.fonts:Add("cwESPText",
 	size		= Clockwork.kernel:FontScreenScale(5.5),
 	weight		= 700,
 	antialiase	= true,
-	additive 	= false
+	additive 	= false,
+	extended 	= true
 });
 Clockwork.fonts:Add("cwTooltip", 
 {
@@ -79,7 +82,8 @@ Clockwork.fonts:Add("cwTooltip",
 	size		= Clockwork.kernel:FontScreenScale(5),
 	weight		= 700,
 	antialiase	= true,
-	additive 	= false
+	additive 	= false,
+	extended	= true
 });
 Clockwork.fonts:Add("cwMenuTextBig",
 {
@@ -87,7 +91,8 @@ Clockwork.fonts:Add("cwMenuTextBig",
 	size		= Clockwork.kernel:FontScreenScale(18),
 	weight		= 700,
 	antialiase	= true,
-	additive 	= false
+	additive 	= false,
+	extended 	= true
 });
 Clockwork.fonts:Add("cwMenuTextTiny",
 {
@@ -95,7 +100,8 @@ Clockwork.fonts:Add("cwMenuTextTiny",
 	size		= Clockwork.kernel:FontScreenScale(7),
 	weight		= 700,
 	antialiase	= true,
-	additive 	= false
+	additive 	= false,
+	extended	= true
 });
 Clockwork.fonts:Add("cwInfoTextFont",
 {
@@ -103,7 +109,8 @@ Clockwork.fonts:Add("cwInfoTextFont",
 	size		= Clockwork.kernel:FontScreenScale(6),
 	weight		= 700,
 	antialiase	= true,
-	additive 	= false
+	additive 	= false,
+	extended	= true
 });
 Clockwork.fonts:Add("cwMenuTextHuge",
 {
@@ -111,7 +118,8 @@ Clockwork.fonts:Add("cwMenuTextHuge",
 	size		= Clockwork.kernel:FontScreenScale(30),
 	weight		= 700,
 	antialiase	= true,
-	additive 	= false
+	additive 	= false,
+	extended	= true
 });
 Clockwork.fonts:Add("cwMenuTextSmall",
 {
@@ -119,7 +127,8 @@ Clockwork.fonts:Add("cwMenuTextSmall",
 	size		= Clockwork.kernel:FontScreenScale(10),
 	weight		= 700,
 	antialiase	= true,
-	additive 	= false
+	additive 	= false,
+	extended	= true
 });
 Clockwork.fonts:Add("cwIntroTextBig",
 {
@@ -127,7 +136,8 @@ Clockwork.fonts:Add("cwIntroTextBig",
 	size		= Clockwork.kernel:FontScreenScale(18),
 	weight		= 700,
 	antialiase	= true,
-	additive 	= false
+	additive 	= false,
+	extended	= true
 });
 Clockwork.fonts:Add("cwIntroTextTiny",
 {
@@ -135,7 +145,8 @@ Clockwork.fonts:Add("cwIntroTextTiny",
 	size		= Clockwork.kernel:FontScreenScale(9),
 	weight		= 700,
 	antialiase	= true,
-	additive 	= false
+	additive 	= false,
+	extended	= true
 });
 Clockwork.fonts:Add("cwIntroTextSmall",
 {
@@ -143,7 +154,8 @@ Clockwork.fonts:Add("cwIntroTextSmall",
 	size		= Clockwork.kernel:FontScreenScale(7),
 	weight		= 700,
 	antialiase	= true,
-	additive 	= false
+	additive 	= false,
+	extended	= true
 });
 Clockwork.fonts:Add("cwLarge3D2D",
 {
@@ -151,7 +163,8 @@ Clockwork.fonts:Add("cwLarge3D2D",
 	size		= Clockwork.kernel:GetFontSize3D(),
 	weight		= 700,
 	antialiase	= true,
-	additive 	= false
+	additive 	= false,
+	extended 	= true
 });
 Clockwork.fonts:Add("cwScoreboardName",
 {
@@ -159,7 +172,8 @@ Clockwork.fonts:Add("cwScoreboardName",
 	size		= Clockwork.kernel:FontScreenScale(7),
 	weight		= 600,
 	antialiase	= true,
-	additive 	= false
+	additive 	= false,
+	extended 	= true
 });
 Clockwork.fonts:Add("cwScoreboardDesc",
 {
@@ -167,7 +181,8 @@ Clockwork.fonts:Add("cwScoreboardDesc",
 	size		= Clockwork.kernel:FontScreenScale(5),
 	weight		= 600,
 	antialiase	= true,
-	additive 	= false
+	additive 	= false,
+	extended 	= true
 });
 Clockwork.fonts:Add("cwCinematicText",
 {
@@ -175,7 +190,8 @@ Clockwork.fonts:Add("cwCinematicText",
 	size		= Clockwork.kernel:FontScreenScale(8),
 	weight		= 700,
 	antialiase	= true,
-	additive 	= false
+	additive 	= false,
+	extended 	= true
 });
 Clockwork.fonts:Add("cwChatSyntax",
 {
@@ -183,5 +199,6 @@ Clockwork.fonts:Add("cwChatSyntax",
 	size		= Clockwork.kernel:FontScreenScale(7),
 	weight		= 600,
 	antialiase	= true,
-	additive 	= false
+	additive 	= false,
+	extended 	= true
 });


### PR DESCRIPTION
This allows fonts to load all UTF-8 characters, resulting in non-english text rendering with proper font.
Bright example of this is here: http://c2n.me/3yUlsb3.jpg
First line is som regular English text.
Second line is some Russian with extended = true.
Third one is some more Russian with extended = false or not set.