### PR TITLE
Add menu_uppercase_text option.

### DIFF
--- a/Clockwork/garrysmod/gamemodes/clockwork/framework/derma/cl_character.lua
+++ b/Clockwork/garrysmod/gamemodes/clockwork/framework/derma/cl_character.lua
@@ -27,6 +27,7 @@ function PANEL:Init()
 		local hugeTextFont = Clockwork.option:GetFont("menu_text_huge");
 		local scrH = ScrH();
 		local scrW = ScrW();
+		local upper = Clockwork.option:GetKey("menu_uppercase_text");
 		
 		self:SetPos(0, 0);
 		self:SetSize(scrW, scrH);
@@ -38,14 +39,22 @@ function PANEL:Init()
 		self.titleLabel = vgui.Create("cwLabelButton", self);
 		self.titleLabel:SetDisabled(true);
 		self.titleLabel:SetFont(hugeTextFont);
-		self.titleLabel:SetText(string.upper(Schema:GetName()));
+		if upper then
+			self.titleLabel:SetText(string.upper(Schema:GetName()));
+		else
+			self.titleLabel:SetText(Schema:GetName());
+		end;
 		
 		local schemaLogo = Clockwork.option:GetKey("schema_logo");
 		
 		self.subLabel = vgui.Create("cwLabelButton", self);
 		self.subLabel:SetDisabled(true);
 		self.subLabel:SetFont(smallTextFont);
-		self.subLabel:SetText(string.upper(Schema:GetDescription()));
+		if upper then
+			self.subLabel:SetText(string.upper(Schema:GetDescription()));
+		else
+			self.subLabel:SetText(Schema:GetDescription());
+		end;
 		self.subLabel:SizeToContents();
 		
 		if (schemaLogo == "") then
@@ -63,7 +72,11 @@ function PANEL:Init()
 		self.authorLabel = vgui.Create("cwLabelButton", self);
 		self.authorLabel:SetDisabled(true);
 		self.authorLabel:SetFont(tinyTextFont);
-		self.authorLabel:SetText("DEVELOPED BY "..string.upper(Schema:GetAuthor()));
+		if upper then
+			self.authorLabel:SetText("DEVELOPED BY "..string.upper(Schema:GetAuthor()));
+		else
+			self.authorLabel:SetText("Developed by "..(Schema:GetAuthor()));
+		end;
 		self.authorLabel:SizeToContents();
 		self.authorLabel:SetPos(self.subLabel.x + (self.subLabel:GetWide() - self.authorLabel:GetWide()), self.subLabel.y + self.subLabel:GetTall() + 4);
 		
@@ -767,14 +780,22 @@ function PANEL:Init()
 	self.nameLabel = vgui.Create("cwLabelButton", self);
 	self.nameLabel:SetDisabled(true);
 	self.nameLabel:SetFont(smallTextFont);
-	self.nameLabel:SetText(string.upper(self.customData.name));
+	if upper then
+		self.nameLabel:SetText(string.upper(self.customData.name));
+	else
+		self.nameLabel:SetText(self.customData.name);
+	end;
 	self.nameLabel:SizeToContents();
 	self.nameLabel:SetPos(0, 80);
 	
 	self.factionLabel = vgui.Create("cwLabelButton", self);
 	self.factionLabel:SetDisabled(true);
 	self.factionLabel:SetFont(tinyTextFont);
-	self.factionLabel:SetText(string.upper(self.customData.faction));
+	if upper then
+		self.factionLabel:SetText(string.upper(self.customData.faction));
+	else
+		self.factionLabel:SetText(self.customData.faction);
+	end;
 	self.factionLabel:SizeToContents();
 	self.factionLabel:SetPos(0, self.nameLabel.y + self.nameLabel:GetTall() + 4);
 	
@@ -925,7 +946,11 @@ function PANEL:Init()
 		local label = vgui.Create("cwLabelButton", self);
 		label:SetDisabled(true);
 		label:SetFont(tinyTextFont);
-		label:SetText(string.upper(v.text));
+		if upper then
+			label:SetText(string.upper(v.text));
+		else
+			label:SetText(v.text);
+		end;
 		label:OverrideTextColor(v.color)
 		label:SizeToContents();
 		label:SetPos((maxWidth / 2) - (label:GetWide()/2), labelY);

--- a/Clockwork/garrysmod/gamemodes/clockwork/framework/derma/cl_menubutton.lua
+++ b/Clockwork/garrysmod/gamemodes/clockwork/framework/derma/cl_menubutton.lua
@@ -27,9 +27,13 @@ function PANEL:SetIcon(iconPath, size)
 end;
 
 function PANEL:SetupLabel(menuItem, panel)
+	local upper = Clockwork.option:GetKey("menu_uppercase_text");
 	self.LabelButton:SetFont(Clockwork.option:GetFont("menu_text_tiny"));
-	self.LabelButton:SetText(string.upper(menuItem.text));
-	
+	if upper then
+		self.LabelButton:SetText(string.upper(menuItem.text));
+	else
+		self.LabelButton:SetText(menuItem.text);
+	end;
 	if (CW_CONVAR_FADEPANEL:GetInt() == 1) then
 		self.LabelButton:SetAlpha(0);
 		self.LabelButton:FadeIn(0.5);

--- a/Clockwork/garrysmod/gamemodes/clockwork/framework/libraries/sh_option.lua
+++ b/Clockwork/garrysmod/gamemodes/clockwork/framework/libraries/sh_option.lua
@@ -82,6 +82,7 @@ Clockwork.option:SetKey("schema_logo", "");
 Clockwork.option:SetKey("intro_image", "");
 Clockwork.option:SetKey("intro_sound", "music/HL2_song25_Teleporter.mp3");
 Clockwork.option:SetKey("menu_music", "music/hl2_song32.mp3");
+Clockwork.option:SetKey("menu_uppercase_text",true)
 Clockwork.option:SetKey("name_cash", "Cash");
 Clockwork.option:SetKey("name_drop", "Drop");
 Clockwork.option:SetKey("top_bars", false);
@@ -141,7 +142,7 @@ if (CLIENT) then
 	
 	Clockwork.option:SetKey("top_bar_width_scale", 0.3);
 	
-	Clockwork.option:SetKey("info_text_icon_size", 16);
+	Clockwork.option:SetKey("info_text_icon_size", 20);
 	Clockwork.option:SetKey("info_text_red_icon", "icon16/exclamation.png");
 	Clockwork.option:SetKey("info_text_green_icon", "icon16/tick.png");
 	Clockwork.option:SetKey("info_text_orange_icon", "icon16/error.png");

--- a/Clockwork/garrysmod/gamemodes/clockwork/framework/sh_kernel.lua
+++ b/Clockwork/garrysmod/gamemodes/clockwork/framework/sh_kernel.lua
@@ -83,10 +83,13 @@ local tableCount = table.Count;
 local tableSort = table.sort;
 local tableAdd = table.Add;
 
+
+
 Clockwork.kernel = Clockwork.kernel or {};
 Clockwork.Timers = Clockwork.Timers or {};
 Clockwork.Libraries = Clockwork.Libraries or {};
 Clockwork.SharedTables = Clockwork.SharedTables or {};
+
 
 --[[
 	@codebase Shared
@@ -1791,6 +1794,7 @@ else
 	function Clockwork.kernel:GetEntityMenuType()
 		return true;
 	end;
+
 
 	-- A function to get the gradient texture.
 	function Clockwork.kernel:GetGradientTexture()
@@ -3545,8 +3549,12 @@ else
 			local textPosX = screenWidth * 0.3;
 			
 			if (cinematicInfo.title) then
-				local cinematicInfoTitle = stringUpper(cinematicInfo.title);
-				local cinematicIntroText = stringUpper(cinematicInfo.text);
+				local cinematicInfoTitle = cinematicInfo.title;
+				local cinematicIntroText = cinematicInfo.text;
+				if (Clockwork.option:GetKey("menu_uppercase_text")) then
+					cinematicInfoTitle = stringUpper(cinematicInfo.title);
+					cinematicIntroText = stringUpper(cinematicInfo.text);
+				end;
 				local introTextSmallFont = Clockwork.option:GetFont("intro_text_small");
 				local introTextBigFont = Clockwork.option:GetFont("intro_text_big");
 				local textWidth, textHeight = self:GetCachedTextSize(introTextBigFont, cinematicInfoTitle);


### PR DESCRIPTION
This pull request adds the option, "menu_uppercase_text", which allows disablement of the all-caps way of doing things Clockwork defaults to.

No issues are present, it has been tested and works correctly.