### PR TITLE
Attempt to fix two errors

### DIFF
--- a/Clockwork/garrysmod/gamemodes/clockwork/plugins/staticents/plugin/sv_hooks.lua
+++ b/Clockwork/garrysmod/gamemodes/clockwork/plugins/staticents/plugin/sv_hooks.lua
@@ -30,7 +30,7 @@ function cwStaticEnts:OnPlayerUserGroupSet(player, usergroup)
 	if (groupCheck[string.lower(usergroup)]) then
 		local staticEnts = {};
 
-		for k, v in ipairs(cwStaticEnts.staticEnts) do
+		for k, v in ipairs(self.staticEnts) do
 			if (IsValid(v) and v:IsValid()) then
 				table.insert(staticEnts, v);
 			end;
@@ -43,8 +43,9 @@ end;
 function cwStaticEnts:PostPlayerSpawn(player, lightSpawn, changeClass, firstSpawn)
 	if (player:IsAdmin()) then
 		local staticEnts = {};
+		self.staticEnts = self.staticEnts or {}
 
-		for k, v in ipairs(cwStaticEnts.staticEnts) do
+		for k, v in ipairs(self.staticEnts) do
 			if (IsValid(v) and v:IsValid()) then
 				table.insert(staticEnts, v);
 			end;

--- a/Clockwork/garrysmod/gamemodes/clockwork/plugins/storage/plugin/sv_plugin.lua
+++ b/Clockwork/garrysmod/gamemodes/clockwork/plugins/storage/plugin/sv_plugin.lua
@@ -71,6 +71,7 @@ end;
 -- A function to save the storage.
 function cwStorage:SaveStorage()
 	local storage = {};
+	self.storage = self.storage or {}
 	
 	for k, v in pairs(self.storage) do
 		if (IsValid(v)) then


### PR DESCRIPTION
This **could** (doesn't have to) fix the following errors:

```
[Clockwork:Storage]
The 'SaveData' hook has failed to run.
gamemodes/clockwork/plugins/storage/plugin/sv_plugin.lua:75: bad argument #1 to 'pairs' (table expected, got nil)
```

```
[Clockwork:Static Entities]
The 'PostPlayerSpawn' hook has failed to run.
gamemodes/clockwork/plugins/staticents/plugin/sv_hooks.lua:47: bad argument #1 to 'ipairs' (table expected, got nil)
```
