### PR TITLE
Fixes issue where first-person legs don't show

### DIFF
--- a/Clockwork/garrysmod/gamemodes/clockwork/plugins/animatedlegs/plugin/cl_plugin.lua
+++ b/Clockwork/garrysmod/gamemodes/clockwork/plugins/animatedlegs/plugin/cl_plugin.lua
@@ -99,7 +99,7 @@ cwAnimatedLegs.RadAngle = nil;
 function cwAnimatedLegs:ShouldDrawLegs()
 	return IsValid(self.LegsEntity) and Clockwork.Client:Alive()
 	and self:CheckDrawVehicle() and GetViewEntity() == Clockwork.Client
-	and !Clockwork.Client:ShouldDrawLocalPlayer() and !Clockwork.Client:GetObserverTarget();
+	and !Clockwork.Client:ShouldDrawLocalPlayer() and !IsValid(Clockwork.Client:GetObserverTarget());
 end;
 
 -- A function to check if a vehicle should be drawn.


### PR DESCRIPTION
This was presumably broken by the latest GMod update. Clockwork.Client:GetObserverTarget() was returning a NULL Entity when the player wasn't spectating any entity.