### PR TITLE
Fixing Flags not updating - Fix to sv_kernel.lua

### DIFF
--- a/Clockwork/garrysmod/gamemodes/clockwork/framework/sv_kernel.lua
+++ b/Clockwork/garrysmod/gamemodes/clockwork/framework/sv_kernel.lua
@@ -759,6 +759,8 @@ function Clockwork:PlayerFlagsGiven(player, flags)
 	if (string.find(flags, "t") and player:Alive()) then
 		cwPly:GiveSpawnWeapon(player, "gmod_tool");
 	end;
+	
+	player:SetSharedVar("Flags", player:GetFlags());
 end;
 
 --[[
@@ -780,6 +782,8 @@ function Clockwork:PlayerFlagsTaken(player, flags)
 			cwPly:TakeSpawnWeapon(player, "gmod_tool");
 		end;
 	end;
+	
+	player:SetSharedVar("Flags", player:GetFlags());
 end;
 
 --[[


### PR DESCRIPTION
Adding player:SetSharedVar("Flags", player:GetFlags()); to the end of both functions: 

function Clockwork:PlayerFlagsGiven(player, flags) & function Clockwork:PlayerFlagsTaken(player, flags)

This fixes the issue of flags not updating. Originally, the character would have to be reloaded to see updated flags. This fixes that.