### PR TITLE
Fixed GiveItems

### DIFF
--- a/Clockwork/garrysmod/gamemodes/clockwork/framework/meta/sv_player.lua
+++ b/Clockwork/garrysmod/gamemodes/clockwork/framework/meta/sv_player.lua
@@ -960,7 +960,7 @@ end;
 -- An easy function to give a table of items to a player.
 function playerMeta:GiveItems(itemTables)
 	for _, itemTable in pairs(itemTables) do
-		self:GiveItem(itemTables)
+		self:GiveItem(itemTable)
 	end
 end
 


### PR DESCRIPTION
Fixed a typo in the GiveItems method that would try to give the table of item tables instead of the value of the for loop.