### PR TITLE
Fixes load character menu overlapping with buttons

### DIFF
--- a/Clockwork/garrysmod/gamemodes/clockwork/framework/derma/cl_character.lua
+++ b/Clockwork/garrysmod/gamemodes/clockwork/framework/derma/cl_character.lua
@@ -705,8 +705,8 @@ end;
 
 -- Called when the layout should be performed.
 function PANEL:PerformLayout(w, h)
-	self:SetPos(0, 96);
-	self:SetSize(ScrW(), ScrH() - (96 * 2));
+	self:SetPos(0, 110);
+	self:SetSize(ScrW(), ScrH() - (110 * 2));
 end;
 
 vgui.Register("cwCharacterList", PANEL, "EditablePanel");


### PR DESCRIPTION
You were only able to press the bottom half of any of the "Previous", "Cancel", or "Next" buttons on the load character menu, as the character list slightly overlapped them. This fixes the issue by reducing the overall height of the panel by a few pixels.