### PR TITLE
Fix Clockwork.kernel:IsShuttingDown - Add Storage check

### DIFF
--- a/Clockwork/garrysmod/gamemodes/clockwork/framework/sv_kernel.lua
+++ b/Clockwork/garrysmod/gamemodes/clockwork/framework/sv_kernel.lua
@@ -4735,7 +4735,7 @@ end
 	@returns {Unknown}
 --]]
 function Clockwork:ShutDown()
-	self.ShuttingDown = true;
+	Clockwork.ShuttingDown = true;
 end;
 
 --[[

--- a/Clockwork/garrysmod/gamemodes/clockwork/plugins/storage/plugin/sv_hooks.lua
+++ b/Clockwork/garrysmod/gamemodes/clockwork/plugins/storage/plugin/sv_hooks.lua
@@ -78,7 +78,7 @@ end;
 
 -- Called when an entity is removed.
 function cwStorage:EntityRemoved(entity)
-	if (IsValid(entity) and !entity.cwIsBelongings) then
+	if (IsValid(entity) and !entity.cwIsBelongings and !Clockwork.kernel:IsShuttingDown()) then
 		Clockwork.entity:DropItemsAndCash(entity.cwInventory, entity.cwCash, entity:GetPos(), entity);
 		entity.cwInventory = nil;
 		entity.cwCash = nil;


### PR DESCRIPTION
Fixes Clockwork.kernel:IsShuttingDown so it doesn't always return nil.
Prevents container items from getting dropped while the server is shutting down.