### PR TITLE
Fix various issues involving the promotion and demotion commands

### DIFF
--- a/Clockwork/garrysmod/gamemodes/clockwork/framework/commands/sh_rankdemote.lua
+++ b/Clockwork/garrysmod/gamemodes/clockwork/framework/commands/sh_rankdemote.lua
@@ -48,7 +48,7 @@ function COMMAND:OnRun(player, arguments)
 
 				Clockwork.player:SetFactionRank(target, Clockwork.faction:GetHigherRank(target:GetFaction(), rankTable));
 
-				Clockwork.player:NotifyAll({"PlayerForceDemoted", player:Name(), target:Name()});
+				Clockwork.player:NotifyAll({"PlayerForceDemoted", player:Name(), target:Name(), (target:GetFactionRank())});
 			else
 				Clockwork.player:Notify(player, {"DemotePermsNeeded"});
 			end;

--- a/Clockwork/garrysmod/gamemodes/clockwork/framework/commands/sh_rankdemote.lua
+++ b/Clockwork/garrysmod/gamemodes/clockwork/framework/commands/sh_rankdemote.lua
@@ -46,7 +46,7 @@ function COMMAND:OnRun(player, arguments)
 			if (Clockwork.player:CanDemote(player, target)) then
 				local rank, rankTable = target:GetFactionRank();
 
-				Clockwork.player:SetFactionRank(target, Clockwork.faction:GetHigherRank(target:GetFaction(), rankTable));
+				Clockwork.player:SetFactionRank(target, Clockwork.faction:GetLowerRank(target:GetFaction(), rankTable));
 
 				Clockwork.player:NotifyAll({"PlayerDemotedPlayer", player:Name(), target:Name(), (target:GetFactionRank())});
 			else

--- a/Clockwork/garrysmod/gamemodes/clockwork/framework/commands/sh_rankdemote.lua
+++ b/Clockwork/garrysmod/gamemodes/clockwork/framework/commands/sh_rankdemote.lua
@@ -48,7 +48,7 @@ function COMMAND:OnRun(player, arguments)
 
 				Clockwork.player:SetFactionRank(target, Clockwork.faction:GetHigherRank(target:GetFaction(), rankTable));
 
-				Clockwork.player:NotifyAll({"PlayerForceDemoted", player:Name(), target:Name(), (target:GetFactionRank())});
+				Clockwork.player:NotifyAll({"PlayerDemotedPlayer", player:Name(), target:Name(), (target:GetFactionRank())});
 			else
 				Clockwork.player:Notify(player, {"DemotePermsNeeded"});
 			end;

--- a/Clockwork/garrysmod/gamemodes/clockwork/framework/commands/sh_rankdemote.lua
+++ b/Clockwork/garrysmod/gamemodes/clockwork/framework/commands/sh_rankdemote.lua
@@ -34,7 +34,7 @@ function COMMAND:OnRun(player, arguments)
 				
 				Clockwork.player:SetFactionRank(target, Clockwork.faction:GetLowerRank(target:GetFaction(), rankTable));
 
-				Clockwork.player:NotifyAll({"PlayerForceDemoted", player:Name(), target:Name(), target:GetFactionRank()});
+				Clockwork.player:NotifyAll({"PlayerForceDemoted", player:Name(), target:Name(), (target:GetFactionRank())});
 			else
 				Clockwork.player:Notify(player, {"YouCannotDemotePlayer"})
 			end;

--- a/Clockwork/garrysmod/gamemodes/clockwork/framework/commands/sh_rankpromote.lua
+++ b/Clockwork/garrysmod/gamemodes/clockwork/framework/commands/sh_rankpromote.lua
@@ -34,7 +34,7 @@ function COMMAND:OnRun(player, arguments)
 				
 				Clockwork.player:SetFactionRank(target, Clockwork.faction:GetHigherRank(target:GetFaction(), rankTable));
 
-				Clockwork.player:NotifyAll({"PlayerForcePromoted", player:Name(), target:Name(), target:GetFactionRank()});
+				Clockwork.player:NotifyAll({"PlayerForcePromoted", player:Name(), target:Name(), (target:GetFactionRank())});
 			else
 				Clockwork.player:Notify(player, {"YouCannotPromotePlayer"});
 			end;
@@ -48,7 +48,7 @@ function COMMAND:OnRun(player, arguments)
 
 				Clockwork.player:SetFactionRank(target, Clockwork.faction:GetHigherRank(target:GetFaction(), rankTable));
 
-				Clockwork.player:NotifyAll({"PlayerPromotedPlayer", player:Name(), target:Name(), target:GetFactionRank()});
+				Clockwork.player:NotifyAll({"PlayerPromotedPlayer", player:Name(), target:Name(), (target:GetFactionRank())});
 			else
 				Clockwork.player:Notify(player, {"PromotePermsNeeded"});
 			end;


### PR DESCRIPTION
The following should be fixed by this PR:

1. The demotion command, when non-forced, would unintentionally cause promotion instead.
2. There are three substitutions required for the demotion notification, however only two were passed into the non-forced demotion notification.
3. The forced demotion notification message was being used for non-forced demotion.
4. Both rankpromote and rankdemote sent the result of GetFactionRank as part of a table of data to the notification function. This has multiple returns, however, and so both of these were included in the table of data sent to the client. In the case of the GetFactionRank function, the second return was a table with string keys, which would end up in a table of substitutions to make in the ReplaceSubs function. When iterating over the subs table, this function would check if the substitution was a table, and would send it to the T function if it was, which would attempt to unpack the table and pass it through the translation process. As the table contains only string keys, the unpack function produced no value, and so nothing would be passed into L, ultimately causing the gsub error reported in issues #427 and #319. TL;DR: bad data was passed into the notification function. The brackets around the call ensure that only the first return is used.
