### PR TITLE
Fixed undefined "self" within metamethod

### DIFF
--- a/Clockwork/garrysmod/gamemodes/clockwork/framework/libraries/sh_config.lua
+++ b/Clockwork/garrysmod/gamemodes/clockwork/framework/libraries/sh_config.lua
@@ -45,7 +45,7 @@ end;
 	@details Called when the config is converted to a string.
 	@returns {Unknown}
 --]]
-function CLASS_TABLE.__tostring()
+function CLASS_TABLE:__tostring()
 	return "CONFIG["..self("key").."]";
 end;
 


### PR DESCRIPTION
Replaced dot with colon in the method definition to ensure "self" is defined.