### PR TITLE
Changed CanCraft to check if OnCraft returns true

### DIFF
--- a/Clockwork/garrysmod/gamemodes/clockwork/framework/libraries/sh_crafting.lua
+++ b/Clockwork/garrysmod/gamemodes/clockwork/framework/libraries/sh_crafting.lua
@@ -145,8 +145,6 @@ function Clockwork.crafting:Craft(player, blueprintTable)
 			message = {"SuccessfulCraft", {blueprintTable("name")}};
 		end;
 		
-		blueprintTable:OnCraft(player);
-		
 		Clockwork.crafting:TakeItems(player, blueprintTable);
 		Clockwork.crafting:GiveItems(player, blueprintTable);
 		
@@ -250,6 +248,10 @@ function Clockwork.crafting:CanCraft(player, blueprintTable)
 	
 	if (!player:CanHoldSpace(itemsSpace)) then
 		return false, {"YourInventoryFull"};
+	end;
+	
+	if (blueprintTable.OnCraft) then
+		return blueprintTable:OnCraft(player);
 	end;
 	
 	return true, "";


### PR DESCRIPTION
I thought that a custom check would be useful for crafting recipes involving custom systems. You could use OnCraft to check for a type of entity near the player for the recipe or, if you're spawning an entity, check to see if there is room in the direction you're facing. PostCraft could be used for things done on a successful craft.