### PR TITLE
Added a new method to blueprints that enable custom requirements

### DIFF
--- a/Clockwork/garrysmod/gamemodes/clockwork/framework/libraries/sh_crafting.lua
+++ b/Clockwork/garrysmod/gamemodes/clockwork/framework/libraries/sh_crafting.lua
@@ -252,6 +252,10 @@ function Clockwork.crafting:CanCraft(player, blueprintTable)
 		return false, {"YourInventoryFull"};
 	end;
 	
+	if (blueprintTable.CanCraft) then
+		return blueprintTable:CanCraft(player);
+	end;
+	
 	return true, "";
 end;
 

--- a/Clockwork/garrysmod/gamemodes/clockwork/framework/libraries/sh_crafting.lua
+++ b/Clockwork/garrysmod/gamemodes/clockwork/framework/libraries/sh_crafting.lua
@@ -77,6 +77,13 @@ end;
 
 --[[
 	@codebase Shared
+	@details Called when checking if an item can be crafted.
+	@param {Entity} Player crafting the blueprint.
+--]]
+function CLASS_TABLE:CanCraft(player) end;
+
+--[[
+	@codebase Shared
 	@details Called when crafting is unsuccessful.
 	@param {Entity} Player crafting the blueprint.
 --]]


### PR DESCRIPTION
the 'CanCraft' callback method can now be used to create custom requirements for blueprints, expanding their functionality. Thanks RJ for the suggestion!