### PR TITLE
Caught error for invalid UTF8 data

### DIFF
--- a/Clockwork/garrysmod/gamemodes/clockwork/framework/sv_kernel.lua
+++ b/Clockwork/garrysmod/gamemodes/clockwork/framework/sv_kernel.lua
@@ -96,9 +96,11 @@ if (system.IsLinux()) then
 	function file.Read(fileName, pathName)
 		local contents = ClockworkFileRead(fileName, pathName);
 		
-		if (contents and string.utf8sub(contents, -1) == "\n") then
-			contents = string.utf8sub(contents, 1, -2);
-		end;
+		pcall(function()
+			if (contents and string.utf8sub(contents, -1) == "\n") then
+				contents = string.utf8sub(contents, 1, -2);
+			end;
+		end);
 		
 		return contents;
 	end;

--- a/Clockwork/garrysmod/gamemodes/clockwork/framework/sv_kernel.lua
+++ b/Clockwork/garrysmod/gamemodes/clockwork/framework/sv_kernel.lua
@@ -95,12 +95,11 @@ if (system.IsLinux()) then
 
 	function file.Read(fileName, pathName)
 		local contents = ClockworkFileRead(fileName, pathName);
-		
-		pcall(function()
-			if (contents and string.utf8sub(contents, -1) == "\n") then
-				contents = string.utf8sub(contents, 1, -2);
-			end;
-		end);
+		local utf8ContentsLength = utf8.len(contents);
+
+		if (contents and utf8ContentsLength and string.utf8sub(contents, -1) == "\n") then
+			contents = string.utf8sub(contents, 1, -2);
+		end;
 		
 		return contents;
 	end;


### PR DESCRIPTION
Catches an error thrown by the utf8sub method when it is passed invalid UTF8 data.

When string.utf8sub from the external library is called, it calls utf8.len from the GMod module, which in turn calls a local decoder function. Naturally, when it is passed data to decode which isn't UTF8 data, it returns nil. This causes utf8.len to send a boolean false as its first return, whereas valid UTF8 data being passed in as a parameter would cause a number to be returned. The unexpected boolean causes the error referenced in #435.

Ultimately, the error is caused by a lack of checking for invalid UTF8 data.