### PR TITLE
Ensure file contents check before UTF8 length check

### DIFF
--- a/Clockwork/garrysmod/gamemodes/clockwork/framework/sv_kernel.lua
+++ b/Clockwork/garrysmod/gamemodes/clockwork/framework/sv_kernel.lua
@@ -95,9 +95,8 @@ if (system.IsLinux()) then
 
 	function file.Read(fileName, pathName)
 		local contents = ClockworkFileRead(fileName, pathName);
-		local utf8ContentsLength = utf8.len(contents);
-
-		if (contents and utf8ContentsLength and string.utf8sub(contents, -1) == "\n") then
+		
+		if (contents and utf8.len(contents) and string.utf8sub(contents, -1) == "\n") then
 			contents = string.utf8sub(contents, 1, -2);
 		end;
 		


### PR DESCRIPTION
My recent UTF8 patch caused the file's content to be checked after its length is obtained. If the file does not exist and the content is nil, the length function errors, which differs from normal behaviour. This change corrects the issue.