### PR TITLE
Localisation support for commands

### DIFF
--- a/Clockwork/garrysmod/gamemodes/clockwork/framework/libraries/client/cl_chatbox.lua
+++ b/Clockwork/garrysmod/gamemodes/clockwork/framework/libraries/client/cl_chatbox.lua
@@ -889,7 +889,7 @@ function Clockwork.chatBox:Paint()
 					local totalText = prefix..v.name;
 					
 					if (isSingleCommand) then
-						totalText = totalText.." "..v.text;
+						totalText = totalText.." "..L(v.text);
 					end;
 					
 					local tWidth, tHeight = Clockwork.kernel:GetCachedTextSize(chatBoxSyntaxFont, totalText);
@@ -903,11 +903,11 @@ function Clockwork.chatBox:Paint()
 					if (isSingleCommand) then
 						local pWidth = Clockwork.kernel:GetCachedTextSize(chatBoxSyntaxFont, prefix..v.name);
 						
-						if (v.tip and v.tip != "") then
-							Clockwork.kernel:DrawSimpleText(v.tip, oX, oY - tHeight - 8, colorWhite);
+						if (v.tip and L(v.tip) != "") then
+							Clockwork.kernel:DrawSimpleText(L(v.tip), oX, oY - tHeight - 8, colorWhite);
 						end;
 						
-						Clockwork.kernel:DrawSimpleText(" "..v.text, oX + pWidth, oY, colorWhite);
+						Clockwork.kernel:DrawSimpleText(" "..L(v.text), oX + pWidth, oY, colorWhite);
 					end;
 					
 					if (k < #commands) then oY = oY - tHeight; end;

--- a/Clockwork/garrysmod/gamemodes/clockwork/framework/libraries/sh_command.lua
+++ b/Clockwork/garrysmod/gamemodes/clockwork/framework/libraries/sh_command.lua
@@ -361,7 +361,7 @@ else
 					<div class="cwCodeText">
 						<i><lang>]]..text..[[</lang></i>
 					</div>
-					]]..commandTable.tip..[[
+					<lang>]]..commandTable.tip..[[</lang>
 				</div>
 				<br>
 			]], true, commandTable.name);

--- a/Clockwork/garrysmod/gamemodes/clockwork/framework/libraries/sh_command.lua
+++ b/Clockwork/garrysmod/gamemodes/clockwork/framework/libraries/sh_command.lua
@@ -310,7 +310,7 @@ if (SERVER) then
 									Clockwork.player:Notify(player, {"NoAccessToCommand", player:Name()});
 								end;
 							else
-								Clockwork.player:Notify(player, commandTable.name.." "..commandTable.text.."!");
+								Clockwork.player:Notify(player, commandTable.name.." "..L(player, commandTable.text).."!");
 							end;
 						end;
 					elseif (!Clockwork.player:GetDeathCode(player, true)) then

--- a/Clockwork/garrysmod/gamemodes/clockwork/framework/sh_kernel.lua
+++ b/Clockwork/garrysmod/gamemodes/clockwork/framework/sh_kernel.lua
@@ -3345,7 +3345,7 @@ else
 				
 				if (IsValid(subMenu)) then
 					if (arguments.toolTip) then
-						subMenu:SetToolTip(arguments.toolTip);
+						subMenu:SetToolTip(T(arguments.toolTip));
 					end;
 				end;
 			else
@@ -3363,7 +3363,7 @@ else
 				local panel = menuPanel.Items[#menuPanel.Items];
 				
 				if (IsValid(panel) and arguments.toolTip) then
-					panel:SetToolTip(arguments.toolTip);
+					panel:SetToolTip(T(arguments.toolTip));
 				end;
 			end;
 		end, minimumWidth);


### PR DESCRIPTION
The localisation updates set command tips and texts to localisation IDs, without adding the mechanism to translate these strings. This PR adds display-time translation of the data.

The relevant areas seem to be the command library (for the notification if too few arguments are provided), the chatbox (for the visual hints when typing out a command), and the quickmenu library (for F1 option tooltips).

I state it as partial support because it doesn't provide support for the directory's command listing. Help entries are first created on command registration, which occurs before the client's language preference. The translation function depends on that convar if a language is not specified, causing an error if you want to translate the command help into the user's set language. So, I have left translation of the directory commands for a later update. Since the help listings are rebuilt when the directory is opened, this could be taken advantage of to produce language translations in future updates.