### PR TITLE
Fixed lack of typing beep

### DIFF
--- a/Clockwork/garrysmod/gamemodes/clockwork/plugins/displaytyping/plugin/sv_hooks.lua
+++ b/Clockwork/garrysmod/gamemodes/clockwork/plugins/displaytyping/plugin/sv_hooks.lua
@@ -13,13 +13,12 @@ function PLUGIN:PlayerStartTypingDisplay(player, code)
 			if (!player.typingBeep) then
 				local rankName, rank = player:GetFactionRank();
 				local faction = Clockwork.faction:FindByID(player:GetFaction());
+				local soundName = rank and rank.startChatNoise or faction and faction.startChatNoise;
 
-				player.typingBeep = true;
-				
-				if (rank and rank.startChatNoise) then
-					player:EmitSound(rank.startChatNoise);
-				elseif (faction and faction.startChatNoise) then
-					player:EmitSound(faction.startChatNoise);
+				if (soundName) then
+					player.typingBeep = true;
+
+					player:EmitSound(soundName);
 				end;
 			end;
 		end;


### PR DESCRIPTION
In cases where a faction or rank typing sound is not specifically defined, Combine players typing will not trigger the default typing beep. This is because of `player.typingBeep = true` currently being set regardless of whether or not the sound is actually emitted in the `displaytyping` plugin. This value is checked by other hooks of the start typing event, thereby stopping them from running. To amend this, I've moved that assignment into the condition, so that it will only run if the sound runs as well.