### PR TITLE
Corrected ValidateTableKeys' value skipping

### DIFF
--- a/Clockwork/garrysmod/gamemodes/clockwork/framework/sh_kernel.lua
+++ b/Clockwork/garrysmod/gamemodes/clockwork/framework/sh_kernel.lua
@@ -5196,10 +5196,16 @@ end;
 	@returns {Unknown}
 --]]
 function Clockwork.kernel:ValidateTableKeys(baseTable)
+	local invalidKeys = {};
+
 	for i = 1, #baseTable do
 		if (!baseTable[i]) then
-			tableRemove(baseTable, i);
+			tableInsert(invalidKeys, i);
 		end;
+	end;
+
+	for i = #invalidKeys, 1, -1 do
+		tableRemove(baseTable, invalidKeys[i]);
 	end;
 end;
 


### PR DESCRIPTION
Currently, `Clockwork.kernel.ValidateTableKeys` performs value removal whilst the table is being iterated through. When the removal is performed, the values in the table with a higher integer index to the removed item will all shift down an index. The result is that the item which moved down into the removed item's index isn't checked. So, even if the value it holds is invalid, it will remain in `baseTable`.

This PR corrects this seemingly unintended behaviour.