### PR TITLE
Removes registration-time addition of commands to the directory listing. Fixes #447.

### DIFF
--- a/Clockwork/garrysmod/gamemodes/clockwork/framework/libraries/sh_command.lua
+++ b/Clockwork/garrysmod/gamemodes/clockwork/framework/libraries/sh_command.lua
@@ -137,10 +137,6 @@ function Clockwork.command:Register(data, name)
 	self.stored[uniqueID].access = data.access or "b";
 	self.stored[uniqueID].arguments = data.arguments or 0;
 
-	if (CLIENT) then
-		self:AddHelp(self.stored[uniqueID]);
-	end;
-
 	return self.stored[uniqueID];
 end;
 


### PR DESCRIPTION
The addition of commands to the directory's help listing at registration time without its removal causes hidden commands to appear in the directory.

I propose the removal of the addition code from the registration process, as it seems to serve no purpose given that `ClockworkDirectoryRebuilt` is called whenever the directory is built, which adds commands to the listing as needed.

This fixes #447.