### PR TITLE
Added value restoration for the PLUGIN global

### DIFF
--- a/Clockwork/garrysmod/gamemodes/clockwork/framework/libraries/sh_plugin.lua
+++ b/Clockwork/garrysmod/gamemodes/clockwork/framework/libraries/sh_plugin.lua
@@ -484,6 +484,8 @@ function Clockwork.plugin:Include(directory, isSchema)
 
 		Schema:Register();
 	else
+		local originalPLUGIN = PLUGIN;
+
 		PLUGIN = self:New();
 		
 		if (SERVER) then
@@ -548,7 +550,7 @@ function Clockwork.plugin:Include(directory, isSchema)
 		end;
 		
 		PLUGIN:Register();
-		PLUGIN = nil;
+		PLUGIN = originalPLUGIN;
 	end;
 end;
 


### PR DESCRIPTION
Sets the `PLUGIN` global back to whatever value it held before it was changed, rather than setting it to nil.

Other than resolving conflicts with any externals that may use this global, this will also permit a Clockwork plugin to include an "external" (not in `myPlugin/plugin/plugins/`) plugin or plugins directory without having its own `PLUGIN` table be overwritten in the process (using, say, `Clockwork.kernel.IncludePlugins`).