### PR TITLE
Added version rounding

### DIFF
--- a/Clockwork/garrysmod/gamemodes/clockwork/framework/sh_kernel.lua
+++ b/Clockwork/garrysmod/gamemodes/clockwork/framework/sh_kernel.lua
@@ -1079,7 +1079,7 @@ if (SERVER) then
 		SCHEMA_GAMEMODE_INFO["name"] = schemaData["title"] or "Undefined";
 		SCHEMA_GAMEMODE_INFO["author"] = schemaData["author"] or "Undefined";
 		SCHEMA_GAMEMODE_INFO["description"] = schemaData["description"] or "Undefined";
-		SCHEMA_GAMEMODE_INFO["version"] = schemaData["version"] or "Undefined";
+		SCHEMA_GAMEMODE_INFO["version"] = schemaData["version"] and math.Round(schemaData["version"], 6) or "Undefined";
 		
 		return SCHEMA_GAMEMODE_INFO;
 	end;


### PR DESCRIPTION
Added rounding of the schema version read from the schema's descriptor file, due to imprecision in the obtained value.

The issue shows itself in the form of this startup message whilst running HL2RP v1.08:
```[Clockwork] Successfully loaded HL2 RP version 1.0799999237061 by kurozael.```
This is due to the fact that `util.KeyValuesToTable`, which is used to obtain schema information from the schema's descriptive .txt file, uses single precision floating point representation to store numbers. Given the fact that Lua 5.1 (and so GLua) uses double precision for its numbers, Lua performs pre-display rounding on the value under the assumption that it is a regular double precision value. To deal with this, we need to perform further rounding ourselves before storage to ensure that the version number displays as intended.