### PR TITLE
Corrected multiplied chat text widths

### DIFF
--- a/Clockwork/garrysmod/gamemodes/clockwork/framework/libraries/client/cl_chatbox.lua
+++ b/Clockwork/garrysmod/gamemodes/clockwork/framework/libraries/client/cl_chatbox.lua
@@ -670,6 +670,10 @@ end;
 function Clockwork.chatBox:WrappedText(newLine, message, color, text, OnHover)
 	local chatBoxTextFont = Clockwork.option:GetFont("chat_box_text");
 	local width, height = Clockwork.kernel:GetTextSize(chatBoxTextFont, text);
+	
+	width = width * (message.multiplier or 1);
+	height = height * (message.multiplier or 1);
+
 	local maximumWidth = ScrW() * 0.6;
 	
 	if (width > maximumWidth) then
@@ -679,7 +683,7 @@ function Clockwork.chatBox:WrappedText(newLine, message, color, text, OnHover)
 		
 		for i = 0, #text do
 			local currentCharacter = string.utf8sub(text, i, i);
-			local currentSingleWidth = Clockwork.kernel:GetTextSize(chatBoxTextFont, currentCharacter);
+			local currentSingleWidth = Clockwork.kernel:GetTextSize(chatBoxTextFont, currentCharacter) * (message.multiplier or 1);
 			
 			if ((currentWidth + currentSingleWidth) >= maximumWidth) then
 				secondText = string.utf8sub(text, i);


### PR DESCRIPTION
Ensures that text items displayed on the same line of the chatbox use the correct width value to determine where to start the display of text.

An example of the fault is shown in this image:
![](https://trello-attachments.s3.amazonaws.com/5688a79d0908834443dbf7e5/362x76/1c22733d332e2498603e42e03f8fb12f/9d4d06b477.jpg)

The text starts at the same place regardless of the multiplication of the text size, because it uses the same width value to determine its starting position regardless. The width value used is only correct when no text scaling is applied. This PR makes sure that the starting position of subsequent texts bases itself off of the actual width of the previous text, rather than the assumed width. As such, with this applied, chat text follows directly after the timestamp, with no overlap or gap.