### PR TITLE
Added localisation for settings tooltips

### DIFF
--- a/Clockwork/garrysmod/gamemodes/clockwork/framework/derma/cl_settings.lua
+++ b/Clockwork/garrysmod/gamemodes/clockwork/framework/derma/cl_settings.lua
@@ -121,9 +121,9 @@ function PANEL:Rebuild()
 				
 				if (IsValid(panel)) then
 					if (v2.class == "checkBox") then
-						panel.Button:SetToolTip(v2.toolTip);
+						panel.Button:SetToolTip(L(v2.toolTip));
 					else
-						panel:SetToolTip(v2.toolTip);
+						panel:SetToolTip(L(v2.toolTip));
 					end;
 				end;
 			end;


### PR DESCRIPTION
Currently tooltips aren't translated from their ID strings to their localised form within the settings menu, and this fixes that.

This can be seen by hovering your mouse over a UI element (like a checkbox or combobox) and observing the text that pops up.