### PR TITLE
Fixes voices directory listing

### DIFF
--- a/Clockwork/garrysmod/gamemodes/clockwork/framework/libraries/sh_voices.lua
+++ b/Clockwork/garrysmod/gamemodes/clockwork/framework/libraries/sh_voices.lua
@@ -137,7 +137,7 @@ function Clockwork.voices:ClockworkInitialized()
 
 					Clockwork.directory:AddCode(k, [[
 						<div class="cwTitleSeperator">
-							]]..string.upper(v2.name)..[[
+							]]..string.upper(v2.command)..[[
 						</div>
 						<div class="cwContentText">
 							<lang>]]..v2.phrase..[[</lang>


### PR DESCRIPTION
There is no name field to the voices entry, so its reference has been replaced with one to the command text.

This issue would not show itself in schemas which implement their own voices library (such as HL2RP v1.08), but rather those which use the Clockwork voices library.