### PR TITLE
Allow speaker to be in more than one voice group

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,2 +1,1 @@
 theme: jekyll-theme-architect
-test

--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,2 @@
 theme: jekyll-theme-architect
+test

--- a/upload/garrysmod/gamemodes/clockwork/framework/sv_kernel.lua
+++ b/upload/garrysmod/gamemodes/clockwork/framework/sv_kernel.lua
@@ -4449,9 +4449,8 @@ function Clockwork:ChatBoxAdjustInfo(info)
 
 			for k, v in pairs(voiceGroups) do
 				if (v.IsPlayerMember(info.speaker)) then
-					voices = v.voices;
-
-					break;
+					for k2,v2 in pairs(v.voices) do table.insert(voices, v2) end;
+					
 				end;
 			end;
 			


### PR DESCRIPTION
Hello, I fixed an issue where this looping and voices = v.voices is going to replace eachother.

So basically I removed the break.

When I removed it I noticed, depending on how many groups "v" from voiceGroups has. It will loop through that a few times, in my case two times. And it will only keep voices from one group.

Now I added support so it can keep voices from multiple voice groups the speaker is in.
&nbsp;

This also is then better, because when the player types voice commands he is already able to see it from other groups, regarding https://github.com/CloudSixteen/Clockwork/blob/master/upload/garrysmod/gamemodes/clockwork/framework/libraries/client/cl_chatbox.lua#L242

&nbsp;

I've tested this and it works perfectly.

When debugging it I looped through v2 and then it lagged. I guess that is normal, because I used print(k3) from v2 and it was waiting until that is finished and so on.

But without print, it works very fast, so yeah.