### PR TITLE
use both weapon.HoldType and weapon:GetHoldType()

### DIFF
--- a/upload/garrysmod/gamemodes/clockwork/framework/libraries/sh_animation.lua
+++ b/upload/garrysmod/gamemodes/clockwork/framework/libraries/sh_animation.lua
@@ -856,7 +856,7 @@ function Clockwork.animation:GetWeaponHoldType(player, weapon)
 	
 	if (self.holdTypes[class]) then
 		holdType = self.holdTypes[class];
-	elseif (IsValid(weapon) then
+	elseif (IsValid(weapon)) then
 		local holdType = weapon.HoldType or weapon:GetHoldType();
 		if (self.convert[holdType]) then
 			holdType = self.convert[holdType];

--- a/upload/garrysmod/gamemodes/clockwork/framework/libraries/sh_animation.lua
+++ b/upload/garrysmod/gamemodes/clockwork/framework/libraries/sh_animation.lua
@@ -852,16 +852,16 @@ end;
 --]]
 function Clockwork.animation:GetWeaponHoldType(player, weapon)
 	local class = string.lower(weapon:GetClass());
-	local weaponTable = weapons.GetStored(class);
 	local holdType = "fist";
 	
 	if (self.holdTypes[class]) then
 		holdType = self.holdTypes[class];
-	elseif (weaponTable and weaponTable.HoldType) then
-		if (self.convert[weaponTable.HoldType]) then
-			holdType = self.convert[weaponTable.HoldType];
+	elseif (IsValid(weapon) then
+		local holdType = weapon.HoldType or weapon:GetHoldType();
+		if (self.convert[holdType]) then
+			holdType = self.convert[holdType];
 		else
-			holdType = weaponTable.HoldType;
+			holdType = holdType;
 		end;
 	else
 		local act = player:Weapon_TranslateActivity(ACT_HL2MP_IDLE) or -1;

--- a/upload/garrysmod/gamemodes/clockwork/framework/libraries/sh_animation.lua
+++ b/upload/garrysmod/gamemodes/clockwork/framework/libraries/sh_animation.lua
@@ -857,13 +857,9 @@ function Clockwork.animation:GetWeaponHoldType(player, weapon)
 	if (self.holdTypes[class]) then
 		holdType = self.holdTypes[class];
 	elseif (IsValid(weapon)) then
-		local holdType = weapon.HoldType or weapon:GetHoldType();
-		
-		if (self.convert[holdType]) then
-			holdType = self.convert[holdType];
-		else
-			holdType = holdType;
-		end;
+		local _holdType = weapon.HoldType or weapon:GetHoldType();
+
+		holdType = self.convert[_holdType] or _holdType;
 	else
 		local act = player:Weapon_TranslateActivity(ACT_HL2MP_IDLE) or -1;
 		

--- a/upload/garrysmod/gamemodes/clockwork/framework/libraries/sh_animation.lua
+++ b/upload/garrysmod/gamemodes/clockwork/framework/libraries/sh_animation.lua
@@ -858,6 +858,7 @@ function Clockwork.animation:GetWeaponHoldType(player, weapon)
 		holdType = self.holdTypes[class];
 	elseif (IsValid(weapon)) then
 		local holdType = weapon.HoldType or weapon:GetHoldType();
+		
 		if (self.convert[holdType]) then
 			holdType = self.convert[holdType];
 		else


### PR DESCRIPTION
instead of relying solely on .HoldType, which some weps do not have defined.