### PR TITLE
Fix invisible characterModel

### DIFF
--- a/upload/garrysmod/gamemodes/clockwork/framework/derma/cl_character.lua
+++ b/upload/garrysmod/gamemodes/clockwork/framework/derma/cl_character.lua
@@ -207,6 +207,8 @@ function PANEL:FadeInModelPanel(model)
 		y = (panel.y + (panel:GetTall() / 2)) - (self.characterModel:GetTall() / 2);
 	end;
 	
+	if y < 0 then y = 2 end;
+	
 	self.characterModel:SetPos(x, y);
 	
 	if (self.characterModel:FadeIn(0.5)) then


### PR DESCRIPTION
When the panel to the left of the characterModel is too small (due to only one row of models for the player to select from) the y will be calculated and set to a negative position. This means that the characterModel will not render at all. Therefore, we clamp the y to be greater than zero to ensure that this doesn't happen.