### PR TITLE
Check if the space system is enabled

### DIFF
--- a/upload/garrysmod/gamemodes/clockwork/framework/libraries/server/sv_storage.lua
+++ b/upload/garrysmod/gamemodes/clockwork/framework/libraries/server/sv_storage.lua
@@ -411,7 +411,7 @@ function Clockwork.storage:GiveTo(player, itemTable)
 		local space = itemTable("storageSpace", itemTable("space"));
 		
 		if ((self:GetWeight(player) + math.max(weight, 0) > storageTable.weight)
-		or (self:GetSpace(player) + math.max(space, 0) > storageTable.space)) then
+		or (Clockwork.inventory:UseSpaceSystem() and (self:GetSpace(player) + math.max(space, 0)) > storageTable.space)) then
 			return false;
 		end;
 	end;


### PR DESCRIPTION
Checks if the space system is enabled before checking if a container has reached the maximum space.

Fixes an issue where you couldn't give a storage more than 100 items while having the system disabled. Thanks, Aspect.