### PR TITLE
Fix Clockwork.kernel:GetPathToGMod() function after util.RelativePathToFull() deprecation.

### DIFF
--- a/upload/garrysmod/gamemodes/clockwork/framework/sh_kernel.lua
+++ b/upload/garrysmod/gamemodes/clockwork/framework/sh_kernel.lua
@@ -420,7 +420,7 @@ end;
 	@returns {Unknown}
 --]]
 function Clockwork.kernel:GetPathToGMod()
-	return util.RelativePathToFull("."):sub(1, -2);
+	return "garrysmod/";
 end;
 
 --[[


### PR DESCRIPTION
Tested by two people so far and works fine.