### PR TITLE
Added AdjustItemClientSideInfo

### DIFF
--- a/upload/garrysmod/gamemodes/clockwork/framework/libraries/sh_item.lua
+++ b/upload/garrysmod/gamemodes/clockwork/framework/libraries/sh_item.lua
@@ -802,6 +802,8 @@ else
 			toolTip = itemTable:GetClientSideInfo(markupObject);
 		end;
 		
+		Clockwork.plugin:Call("AdjustItemClientSideInfo", itemTable, toolTip);
+		
 		if (itemTable.GetClientSideDescription
 		and itemTable:GetClientSideDescription()) then
 			description = itemTable:GetClientSideDescription();


### PR DESCRIPTION
Allows a way to adjust item tooltips outside of the items themselves.